### PR TITLE
Fix up flow types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 // @flow
 
-export type TrashablePromise<T> = Promise<T> & { trash: () => void };
+export type TrashablePromise<T> = Promise<T> & {
+  then: <S: T>(T) => S,
+  catch: any => any,
+  finally: () => void,
+  trash: () => void,
+};
 
 function makeTrashable<T>(promise: Promise<T>): TrashablePromise<T> {
   let trash = () => {};


### PR DESCRIPTION
As of flow 0.89 this should work correctly. Without this you get `Error:(171, 8) Cannot call `registerPromise(...).then` because property `then` is missing in object type [1].`.

It seems that `Promise<T> & {...` doesn't get all the functions of `Promise` so by manually adding them all we should be OK.

Related to https://github.com/hjylewis/trashable-react/pull/6